### PR TITLE
Tolerate TRAILER version of unsigned payload

### DIFF
--- a/lib/signature/v4.js
+++ b/lib/signature/v4.js
@@ -17,7 +17,7 @@ exports.parseHeader = function (headers) {
   }
   if (
     !headers['x-amz-content-sha256'].match(
-      /^(UNSIGNED-PAYLOAD|STREAMING-AWS4-HMAC-SHA256-PAYLOAD|STREAMING-UNSIGNED-PAYLOAD-TRAILER|[0-9A-Fa-f]{64})$/,
+      /^(UNSIGNED-PAYLOAD|STREAMING-AWS4-HMAC-SHA256-PAYLOAD(-TRAILER)?|STREAMING-UNSIGNED-PAYLOAD-TRAILER|[0-9A-Fa-f]{64})$/,
     )
   ) {
     throw new S3Error(


### PR DESCRIPTION
It looks like some of the other API calls need this one to be allowed too.

There might be something to be said for just deleting this validation in it's entirety, we trust the SDK to make the calls correctly, so as long as the s3 mock accepts the uploads, it's good enough for our use case.